### PR TITLE
0.002 - Store "secure" and "domain" settings on session create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ nytprof.out
 *.bs
 Dancer-Session-Redis-JSON-*
 *~
+Makefile.PL
+

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,0 +1,7 @@
+use strict;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME            => 'Dancer::Session::Redis::JSON',
+    VERSION_FROM    => 'lib/Dancer/Session/Redis/JSON.pm'
+);

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,7 +1,0 @@
-use strict;
-use ExtUtils::MakeMaker;
-
-WriteMakefile(
-    NAME            => 'Dancer::Session::Redis::JSON',
-    VERSION_FROM    => 'lib/Dancer/Session/Redis/JSON.pm'
-);

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Dancer::Session::Redis::JSON - Session store in Redis with JSON serialization
 
 # VERSION
 
-version 0.001
+version 0.002
 
 # SYNOPSIS
 

--- a/dist.ini
+++ b/dist.ini
@@ -4,7 +4,7 @@ license = MIT
 copyright_holder = Forest Belton
 copyright_year   = 2014
 
-version = 0.001
+version = 0.002
 
 [@Basic]
 [PodWeaver]

--- a/lib/Dancer/Session/Redis/JSON.pm
+++ b/lib/Dancer/Session/Redis/JSON.pm
@@ -4,7 +4,7 @@ package Dancer::Session::Redis::JSON;
 
 # VERSION
 # ABSTRACT: Session store in Redis with JSON serialization
-$VERSION = "0.001";
+$VERSION = "0.002";
 
 use base 'Dancer::Session::Abstract';
 
@@ -36,7 +36,10 @@ method update() {
             path           => setting('session_cookie_path')  // '/',
             httpOnly       => setting('session_is_http_only') // JSON::true,
             expires        => setting('session_expires'),
-            originalMaxAge => undef
+            expires        => setting('session_expires'),
+            secure         => setting('session_secure'),
+            domain         => setting('session_domain'),
+            originalMaxAge => undef,
         },
     };
 

--- a/lib/Dancer/Session/Redis/JSON.pm
+++ b/lib/Dancer/Session/Redis/JSON.pm
@@ -4,6 +4,7 @@ package Dancer::Session::Redis::JSON;
 
 # VERSION
 # ABSTRACT: Session store in Redis with JSON serialization
+$VERSION = "0.001";
 
 use base 'Dancer::Session::Abstract';
 


### PR DESCRIPTION
redis-connect will parse these options to express-session from the store https://github.com/tj/connect-redis/blob/master/lib/connect-redis.js#L155

These arguments are passed into the cookie library: https://www.npmjs.com/package/cookie#domain

Basically this is taking some new Perl Dancer settings and shoving them into Redis so that node can read out the right values so it can initialize the session properly (and doesn't set a cookie with inconsistent security/domain settings).

We're using this version internally but wanted to contribute this back ... if you're not interested in maintaining this library going into the future let me know and we can figure it out 😄 
